### PR TITLE
fix dependence 'afunix' in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {deps,
  [
   {exometer_core, "1.5.7"},
-  {afunix, ".*", {git, "git://github.com/tonyrog/afunix.git", "3df8a32"}}
+  {afunix, ".*", {git, "git://github.com/tonyrog/afunix.git", "80e2248da1e2cc361acec09a82b76f56586d09f2"}}
  ]}.
 
 {profiles,


### PR DESCRIPTION
Dependency was changed to actual:

`Old version {afunix, ".*", {git, "git://github.com/tonyrog/afunix.git", "3df8a32"}} - was changed to actual version {afunix, ".*", {git, "git://github.com/tonyrog/afunix.git", "80e2248da1e2cc361acec09a82b76f56586d09f2"}}`

In new version afunix was fixed mistake of compile for versions OTP early 20

